### PR TITLE
Fixes #148: Adds missing metadata properties to GTFS dataset entity creation

### DIFF
--- a/usecase/create_dataset_entity_for_gtfs_metadata.py
+++ b/usecase/create_dataset_entity_for_gtfs_metadata.py
@@ -4,12 +4,6 @@ from dotenv import load_dotenv
 from wikibaseintegrator import wbi_core
 from utilities.request_utils import import_entity
 from utilities.constants import (
-    DATATYPE,
-    PROP_ID,
-    VALUE,
-    RANK,
-    IF_EXISTS,
-    NORMAL,
     PREFERRED,
     INSTANCE_PROP,
     SOURCE_ENTITY_PROP,
@@ -21,7 +15,23 @@ from utilities.constants import (
     END_TIMESTAMP_PROP,
     MD5_HASH_PROP,
     DATASET_VERSION_PROP,
+    ORDER_PROP,
+    BOUNDING_BOX_PROP,
+    BOUNDING_OCTAGON_PROP,
+    NUM_OF_STOPS_PROP,
+    NUM_OF_STATIONS_PROP,
+    NUM_OF_ENTRANCES_PROP,
+    NUM_OF_AGENCIES_PROP,
+    NUM_OF_ROUTES_PROP,
+    ROUTE_TYPE_PROP,
     GTFS_SCHEDULE_DATA_FORMAT,
+    LAT,
+    LON,
+    GLOBE_PRECISION,
+    GLOBE_URL,
+    STOP_KEY,
+    STATION_KEY,
+    ENTRANCE_KEY,
 )
 from utilities.validators import validate_gtfs_representation, validate_api_url
 
@@ -31,6 +41,21 @@ STAGING_PASSWORD = os.getenv("STAGING_PASSWORD")
 
 REPLACE = "REPLACE"
 APPEND = "APPEND"
+
+
+def create_geographical_property(order_key, corner_value, property_type):
+    order_qualifier = [
+        wbi_core.Quantity(quantity=order_key, prop_nr=ORDER_PROP, is_qualifier=True)
+    ]
+
+    return wbi_core.GlobeCoordinate(
+        latitude=corner_value.get(LAT),
+        longitude=corner_value.get(LON),
+        precision=GLOBE_PRECISION,
+        globe=GLOBE_URL,
+        prop_nr=property_type,
+        qualifiers=order_qualifier,
+    )
 
 
 def create_dataset_entity_for_gtfs_metadata(gtfs_representation, api_url):
@@ -43,98 +68,132 @@ def create_dataset_entity_for_gtfs_metadata(gtfs_representation, api_url):
     validate_gtfs_representation(gtfs_representation)
     metadata = gtfs_representation.metadata
 
-    version_name_label = metadata.dataset_version_name
-    instance_prop = {
-        DATATYPE: wbi_core.ItemID,
-        PROP_ID: INSTANCE_PROP,
-        VALUE: GTFS_SCHEDULE_DATA_FORMAT,
-        RANK: NORMAL,
-        IF_EXISTS: REPLACE,
-    }
-    source_entity_prop = {
-        DATATYPE: wbi_core.ItemID,
-        PROP_ID: SOURCE_ENTITY_PROP,
-        VALUE: metadata.source_entity_code,
-        RANK: NORMAL,
-        IF_EXISTS: REPLACE,
-    }
-    main_timezone_prop = {
-        DATATYPE: wbi_core.String,
-        PROP_ID: MAIN_TIMEZONE_PROP,
-        VALUE: metadata.main_timezone,
-        RANK: PREFERRED,
-        IF_EXISTS: REPLACE,
-    }
-    main_language_code_prop = {
-        DATATYPE: wbi_core.String,
-        PROP_ID: MAIN_LANGUAGE_CODE_PROP,
-        VALUE: metadata.main_language_code,
-        RANK: PREFERRED,
-        IF_EXISTS: REPLACE,
-    }
-    start_service_date_prop = {
-        DATATYPE: wbi_core.String,
-        PROP_ID: START_SERVICE_DATE_PROP,
-        VALUE: metadata.start_service_date,
-        RANK: NORMAL,
-        IF_EXISTS: REPLACE,
-    }
-    end_service_date_prop = {
-        DATATYPE: wbi_core.String,
-        PROP_ID: END_SERVICE_DATE_PROP,
-        VALUE: metadata.end_service_date,
-        RANK: NORMAL,
-        IF_EXISTS: REPLACE,
-    }
-    start_timestamp_prop = {
-        DATATYPE: wbi_core.String,
-        PROP_ID: START_TIMESTAMP_PROP,
-        VALUE: metadata.start_timestamp,
-        RANK: NORMAL,
-        IF_EXISTS: REPLACE,
-    }
-    end_timestamp_prop = {
-        DATATYPE: wbi_core.String,
-        PROP_ID: END_TIMESTAMP_PROP,
-        VALUE: metadata.end_timestamp,
-        RANK: NORMAL,
-        IF_EXISTS: REPLACE,
-    }
-    md5_hash_prop = {
-        DATATYPE: wbi_core.String,
-        PROP_ID: MD5_HASH_PROP,
-        VALUE: metadata.md5_hash,
-        RANK: NORMAL,
-        IF_EXISTS: REPLACE,
-    }
+    dataset_data = []
 
-    dataset_props = [
-        instance_prop,
-        source_entity_prop,
-        main_timezone_prop,
-        main_language_code_prop,
-        start_service_date_prop,
-        end_service_date_prop,
-        start_timestamp_prop,
-        end_timestamp_prop,
-        md5_hash_prop,
-    ]
-    metadata.dataset_version_entity_code = import_entity(
-        STAGING_USERNAME, STAGING_PASSWORD, dataset_props, version_name_label
+    # Instance property
+    dataset_data.append(
+        wbi_core.ItemID(value=GTFS_SCHEDULE_DATA_FORMAT, prop_nr=INSTANCE_PROP)
     )
 
-    version_prop = {
-        DATATYPE: wbi_core.ItemID,
-        PROP_ID: DATASET_VERSION_PROP,
-        VALUE: metadata.dataset_version_entity_code,
-        RANK: NORMAL,
-        IF_EXISTS: APPEND,
-    }
-    source_props = [version_prop]
+    # Source entity property
+    dataset_data.append(
+        wbi_core.ItemID(value=metadata.source_entity_code, prop_nr=SOURCE_ENTITY_PROP)
+    )
+
+    # Main timezone property
+    dataset_data.append(
+        wbi_core.String(
+            value=metadata.main_timezone, prop_nr=MAIN_TIMEZONE_PROP, rank=PREFERRED
+        )
+    )
+
+    # Main language code property
+    dataset_data.append(
+        wbi_core.String(
+            value=metadata.main_language_code,
+            prop_nr=MAIN_LANGUAGE_CODE_PROP,
+            rank=PREFERRED,
+        )
+    )
+
+    # Start service date property
+    dataset_data.append(
+        wbi_core.String(
+            value=metadata.start_service_date, prop_nr=START_SERVICE_DATE_PROP
+        )
+    )
+
+    # End service date property
+    dataset_data.append(
+        wbi_core.String(value=metadata.end_service_date, prop_nr=END_SERVICE_DATE_PROP)
+    )
+
+    # Start timestamp property
+    dataset_data.append(
+        wbi_core.String(value=metadata.start_timestamp, prop_nr=START_TIMESTAMP_PROP)
+    )
+
+    # End timestamp property
+    dataset_data.append(
+        wbi_core.String(value=metadata.end_timestamp, prop_nr=END_TIMESTAMP_PROP)
+    )
+
+    # MD5 hash property
+    dataset_data.append(wbi_core.String(value=metadata.md5_hash, prop_nr=MD5_HASH_PROP))
+
+    # Bounding box property
+    for order_key, corner_value in metadata.bounding_box.items():
+        dataset_data.append(
+            create_geographical_property(order_key, corner_value, BOUNDING_BOX_PROP)
+        )
+
+    # Bounding octagon property
+    for order_key, corner_value in metadata.bounding_octagon.items():
+        dataset_data.append(
+            create_geographical_property(order_key, corner_value, BOUNDING_OCTAGON_PROP)
+        )
+
+    # Number of stops property
+    dataset_data.append(
+        wbi_core.Quantity(
+            quantity=metadata.stops_count_by_type.get(STOP_KEY),
+            prop_nr=NUM_OF_STOPS_PROP,
+        )
+    )
+
+    # Number of stations property
+    dataset_data.append(
+        wbi_core.Quantity(
+            quantity=metadata.stops_count_by_type.get(STATION_KEY),
+            prop_nr=NUM_OF_STATIONS_PROP,
+        )
+    )
+
+    # Number of entrances property
+    dataset_data.append(
+        wbi_core.Quantity(
+            quantity=metadata.stops_count_by_type.get(ENTRANCE_KEY),
+            prop_nr=NUM_OF_ENTRANCES_PROP,
+        )
+    )
+
+    # Number of agencies property
+    dataset_data.append(
+        wbi_core.Quantity(
+            quantity=metadata.agencies_count, prop_nr=NUM_OF_AGENCIES_PROP
+        )
+    )
+
+    # Number of stops property
+    for route_key, route_value in metadata.routes_count_by_type.items():
+        route_qualifier = [
+            wbi_core.String(value=route_key, prop_nr=ROUTE_TYPE_PROP, is_qualifier=True)
+        ]
+        dataset_data.append(
+            wbi_core.Quantity(
+                quantity=route_value,
+                prop_nr=NUM_OF_ROUTES_PROP,
+                qualifiers=route_qualifier,
+            )
+        )
+
+    # Dataset version entity label
+    version_name_label = metadata.dataset_version_name
+
+    metadata.dataset_version_entity_code = import_entity(
+        STAGING_USERNAME, STAGING_PASSWORD, dataset_data, version_name_label
+    )
+
+    version_prop = wbi_core.ItemID(
+        value=metadata.dataset_version_entity_code,
+        prop_nr=DATASET_VERSION_PROP,
+        if_exists=APPEND,
+    )
+    source_data = [version_prop]
     metadata.source_entity_code = import_entity(
         STAGING_USERNAME,
         STAGING_PASSWORD,
-        source_props,
+        source_data,
         item_id=metadata.source_entity_code,
     )
 

--- a/usecase/process_routes_count_by_type_for_gtfs_metadata.py
+++ b/usecase/process_routes_count_by_type_for_gtfs_metadata.py
@@ -12,16 +12,16 @@ TROLLEY_BUS = 11
 MONORAIL = 12
 ROUTE_TYPE = "route_type"
 
-TRAM_KEY = "tram"
-SUBWAY_KEY = "subway"
-RAIL_KEY = "rail"
-BUS_KEY = "bus"
-FERRY_KEY = "ferry"
-CABLE_TRAM_KEY = "cable_tram"
-AERIAL_LIFT_KEY = "aerial_lift"
-FUNICULAR_KEY = "funicular"
-TROLLEY_BUS_KEY = "trolley_bus"
-MONORAIL_KEY = "monorail"
+TRAM_KEY = "Tram"
+SUBWAY_KEY = "Subway"
+RAIL_KEY = "Rail"
+BUS_KEY = "Bus"
+FERRY_KEY = "Ferry"
+CABLE_TRAM_KEY = "Cable tram"
+AERIAL_LIFT_KEY = "Aerial lift"
+FUNICULAR_KEY = "Funicular"
+TROLLEY_BUS_KEY = "Trolleybus"
+MONORAIL_KEY = "Monorail"
 
 
 def process_routes_count_by_type_for_gtfs_metadata(gtfs_representation):

--- a/usecase/process_stops_count_by_type_for_gtfs_metadata.py
+++ b/usecase/process_stops_count_by_type_for_gtfs_metadata.py
@@ -1,13 +1,13 @@
+from utilities.constants import (
+    STOP_KEY,
+    STATION_KEY,
+    ENTRANCE_KEY,
+    STOP,
+    STATION,
+    ENTRANCE,
+    LOCATION_TYPE,
+)
 from utilities.validators import validate_gtfs_representation
-
-STOP = 0
-STATION = 1
-ENTRANCE = 2
-LOCATION_TYPE = "location_type"
-
-STOP_KEY = "stop"
-STATION_KEY = "station"
-ENTRANCE_KEY = "entrance"
 
 
 def process_stops_count_by_type_for_gtfs_metadata(gtfs_representation):

--- a/usecase/test/test_create_dataset_entity_for_gtfs_metadata.py
+++ b/usecase/test/test_create_dataset_entity_for_gtfs_metadata.py
@@ -36,8 +36,11 @@ class TestCreateDatasetEntity(TestCase):
             STAGING_API_URL,
         )
 
+    @mock.patch("usecase.create_dataset_entity_for_gtfs_metadata.wbi_core")
     @mock.patch("usecase.create_dataset_entity_for_gtfs_metadata.import_entity")
-    def test_create_dataset_entity_with_valid_parameter(self, mock_importer):
+    def test_create_dataset_entity_with_valid_parameter(
+        self, mock_importer, mock_wbi_core
+    ):
         mock_importer.side_effect = [
             "test_dataset_version_code",
             "test_source_entity_code",

--- a/utilities/constants.py
+++ b/utilities/constants.py
@@ -15,6 +15,15 @@ END_TIMESTAMP_PROP = "P67"
 MD5_HASH_PROP = "P61"
 DATASET_VERSION_PROP = "P64"
 STABLE_URL_PROP = "P55"
+ORDER_PROP = "P38"
+BOUNDING_BOX_PROP = "P63"
+BOUNDING_OCTAGON_PROP = "P68"
+NUM_OF_STOPS_PROP = "P69"
+NUM_OF_STATIONS_PROP = "P70"
+NUM_OF_ENTRANCES_PROP = "P71"
+NUM_OF_AGENCIES_PROP = "P72"
+NUM_OF_ROUTES_PROP = "P73"
+ROUTE_TYPE_PROP = "P74"
 
 # Define regex pattern for dataset version entity code in response retrieved by SPARQL query
 SPARQL_ENTITY_CODE_REGEX = "/(Q.+?)-"
@@ -46,6 +55,23 @@ PROP_ID = "prop_id"
 IF_EXISTS = "if_exists"
 NORMAL = "normal"
 PREFERRED = "preferred"
+GLOBE_PRECISION = 1.0e-6
+GLOBE_URL = "http://www.wikidata.org/entity/Q2"
+LAT = "latitude"
+LON = "longitude"
+
+STOP_LAT = "stop_lat"
+STOP_LON = "stop_lon"
+IS_ADDITION = "is_addition"
+IS_MAXIMUM = "is_maximum"
+
+STOP_KEY = "stop"
+STATION_KEY = "station"
+ENTRANCE_KEY = "entrance"
+STOP = 0
+STATION = 1
+ENTRANCE = 2
+LOCATION_TYPE = "location_type"
 
 SPARQL_A = "a"
 SVC_SOURCE_PROPERTY_URL = "http://wikibase.svc/prop/statement/P48"

--- a/utilities/geographical_utils.py
+++ b/utilities/geographical_utils.py
@@ -1,18 +1,11 @@
 import re
 from LatLon23 import Latitude, Longitude
-
-STOP_LAT = "stop_lat"
-STOP_LON = "stop_lon"
-LAT = "latitude"
-LON = "longitude"
+from utilities.constants import STOP_LAT, STOP_LON, LAT, LON, IS_ADDITION, IS_MAXIMUM
 
 LAT_LON_23_DEGREES = "d"
 LAT_LON_23_MINUTES = "m"
 LAT_LON_23_SECONDS = "S"
 LAT_LON_23_HEMISPHERE = "H"
-
-IS_ADDITION = "is_addition"
-IS_MAXIMUM = "is_maximum"
 
 OCTAGON_LOWER_RIGHT_CORNER_MAP = {
     IS_ADDITION: False,

--- a/utilities/request_utils.py
+++ b/utilities/request_utils.py
@@ -27,18 +27,8 @@ wbi_config["SPARQL_ENDPOINT_URL"] = STAGING_SPARQL_BIGDATA_URL
 wbi_config["WIKIBASE_URL"] = SVC_URL
 
 
-def import_entity(username, password, properties, label="", item_id=""):
+def import_entity(username, password, data, label="", item_id=""):
     login_instance = wbi_login.Login(user=username, pwd=password, use_clientlogin=True)
-
-    data = []
-    for prop in properties:
-        data_entry = prop[DATATYPE](
-            value=prop[VALUE],
-            prop_nr=prop[PROP_ID],
-            rank=prop[RANK],
-            if_exists=prop[IF_EXISTS],
-        )
-        data.append(data_entry)
 
     entity = wbi_core.ItemEngine(data=data, item_id=item_id)
     if label:


### PR DESCRIPTION
**Summary:**

This PR adds the missing properties to the GTFS dataset entity creation.

Implement

- Adds Bounding box and octagon properties
- Adds Number of agencies, routes and stops properties

Changes made

- `create_dataset_entity_for_gtfs_metadata.py` was adapted to reflect changes
- `process_routes_count_by_type_for_gtfs_metadata.py` and `process_stops_count_by_type_for_gtfs_metadata.py` were adapted to reflect changes.
- `request_utils.py` was adapted

Mobility Database properties added ([displayed here](http://staging.mobilitydatabase.org/w/index.php?title=Special:ListProperties/&limit=50&offset=50))

- Bounding octagon (P68)
- Number of stops (P69)
- Number of stations (P70)
- Number of entrances (P71)
- Number of agencies (P72)
- Number of routes (P73)
- route type (P74)


**Expected behavior:** 

Adds the bounding box and octagon, Number of agencies, routes and stops to a Dataset entity during its creation.


Please make sure these boxes are checked before submitting your pull request - thanks!

- [x] Run the unit tests with `pytest` to make sure you didn't break anything
- [x] Format the title like "<short description of fix and changes>" (for example - "Check for null value before using field")
- [x] Linked all relevant issues
- [ ] ~Include screenshot(s) showing how this pull request works and fixes the issue(s)~