### PR TITLE
Fixes #193: Timestamp extraction fails when encountering NaN values

### DIFF
--- a/representation/dataset_infos.py
+++ b/representation/dataset_infos.py
@@ -9,3 +9,15 @@ class DatasetInfos:
         self.sha1_hash = ""
         self.previous_sha1_hashes = set()
         self.previous_versions = set()
+
+    def __str__(self):
+        return (
+            f"Source name: {self.source_name}\n"
+            f"Entity code: {self.entity_code}\n"
+            f"URL: {self.url}\n"
+            f"Zip path: {self.zip_path}\n"
+            f"Download date: {self.download_date}\n"
+            f"SHA-1 hash: {self.sha1_hash}\n"
+            f"Previous SHA-1 hashes: {self.previous_sha1_hashes}\n"
+            f"Previous versions: {self.previous_versions}\n"
+        )

--- a/usecase/process_timestamp_for_gtfs_metadata.py
+++ b/usecase/process_timestamp_for_gtfs_metadata.py
@@ -64,27 +64,32 @@ def process_timestamp_for_gtfs_metadata(gtfs_representation, timestamp_map):
     # Get last end service date with max()
     service_date = getattr(dates, timestamp_map[MIN_MAX_ATTR])()
 
-    # Get every stop time of the dataset for the start service date
-    # or
-    # Get every stop time of the dataset for the end service date
-    stop_times_for_date = get_gtfs_stop_times_for_date(
-        dataset, dataset_dates, service_date
-    )
+    # Continue only if the dataset dates is not an empty dataframe and service date found is not null
+    if not dataset_dates.empty and pd.notna(service_date):
+        # Get every stop time of the dataset for the start service date
+        # or
+        # Get every stop time of the dataset for the end service date
+        stop_times_for_date = get_gtfs_stop_times_for_date(
+            dataset, dataset_dates, service_date, timestamp_map[STOP_TIME_KEY]
+        )
 
-    # Get first arrival time of the first start service date with min()
-    # or
-    # Get last departure time of the last end service date with max()
-    stop_time = getattr(
-        stop_times_for_date[timestamp_map[STOP_TIME_KEY]], timestamp_map[MIN_MAX_ATTR]
-    )()
+        # Get first arrival time of the first start service date with min()
+        # or
+        # Get last departure time of the last end service date with max()
+        stop_time = getattr(
+            stop_times_for_date[timestamp_map[STOP_TIME_KEY]],
+            timestamp_map[MIN_MAX_ATTR],
+        )()
 
-    # Compute UTC offset for the GTFS dataset
-    timezone_offset = get_gtfs_timezone_utc_offset(dataset)
+        # Continue only if the stop time found is not null
+        if pd.notna(stop_time):
+            # Compute UTC offset for the GTFS dataset
+            timezone_offset = get_gtfs_timezone_utc_offset(dataset)
 
-    # Build and set timestamp string in ISO 8601 YYYY-MM-DDThh:mm:ss±hh:mm format
-    timestamp = (
-        f"{service_date.strftime(TIMESTAMP_FORMAT)}T{stop_time}{timezone_offset}"
-    )
-    setattr(metadata, timestamp_map[TIMESTAMP_ATTR], timestamp)
+            # Continue if the timezone offset is not empty
+            if len(timezone_offset) != 0:
+                # Build and set timestamp string in ISO 8601 YYYY-MM-DDThh:mm:ss±hh:mm format
+                timestamp = f"{service_date.strftime(TIMESTAMP_FORMAT)}T{stop_time}{timezone_offset}"
+                setattr(metadata, timestamp_map[TIMESTAMP_ATTR], timestamp)
 
     return gtfs_representation

--- a/usecase/test/test_process_end_timestamp_for_gtfs_metadata.py
+++ b/usecase/test/test_process_end_timestamp_for_gtfs_metadata.py
@@ -58,3 +58,106 @@ class TestProcessEndTimestampForGtfsMetadata(TestCase):
         under_test = process_end_timestamp_for_gtfs_metadata(mock_gtfs_representation)
         self.assertIsInstance(under_test, GtfsRepresentation)
         self.assertEqual(mock_metadata.end_timestamp, "2020-10-10T05:00:00-05:00")
+
+    @mock.patch("usecase.process_timestamp_for_gtfs_metadata.get_gtfs_dates_by_type")
+    @mock.patch(
+        "usecase.process_timestamp_for_gtfs_metadata.get_gtfs_timezone_utc_offset"
+    )
+    @mock.patch(
+        "usecase.process_timestamp_for_gtfs_metadata.get_gtfs_stop_times_for_date"
+    )
+    def test_process_end_timestamp_execution_with_empty_dates_by_type(
+        self, mock_stop_times_for_date, mock_utc_offset, mock_dates_by_type
+    ):
+        mock_dataset = MagicMock()
+        mock_dataset.__class__ = Feed
+
+        mock_metadata = MagicMock()
+        mock_metadata.__class__ = GtfsMetadata
+
+        mock_gtfs_representation = MagicMock()
+        mock_gtfs_representation.__class__ = GtfsRepresentation
+        type(mock_gtfs_representation).dataset = mock_dataset
+        type(mock_gtfs_representation).metadata = mock_metadata
+
+        mock_stop_times_for_date.return_value = pd.DataFrame(
+            {"trip_id": ["test_trip_id"], "departure_time": ["05:00:00"]}
+        )
+
+        mock_dates_by_type.return_value = pd.DataFrame({"service_id": [], "date": []})
+
+        mock_utc_offset.return_value = "-05:00"
+
+        under_test = process_end_timestamp_for_gtfs_metadata(mock_gtfs_representation)
+        self.assertIsInstance(under_test, GtfsRepresentation)
+        mock_metadata.end_timestamp.assert_not_called()
+
+    @mock.patch("usecase.process_timestamp_for_gtfs_metadata.get_gtfs_dates_by_type")
+    @mock.patch(
+        "usecase.process_timestamp_for_gtfs_metadata.get_gtfs_timezone_utc_offset"
+    )
+    @mock.patch(
+        "usecase.process_timestamp_for_gtfs_metadata.get_gtfs_stop_times_for_date"
+    )
+    def test_process_end_timestamp_execution_with_empty_stop_times_for_date(
+        self, mock_stop_times_for_date, mock_utc_offset, mock_dates_by_type
+    ):
+        mock_dataset = MagicMock()
+        mock_dataset.__class__ = Feed
+
+        mock_metadata = MagicMock()
+        mock_metadata.__class__ = GtfsMetadata
+
+        mock_gtfs_representation = MagicMock()
+        mock_gtfs_representation.__class__ = GtfsRepresentation
+        type(mock_gtfs_representation).dataset = mock_dataset
+        type(mock_gtfs_representation).metadata = mock_metadata
+
+        mock_stop_times_for_date.return_value = pd.DataFrame(
+            {"trip_id": [], "departure_time": []}
+        )
+
+        mock_dates_by_type.return_value = pd.DataFrame(
+            {"service_id": ["test_service_id"], "date": ["20201010"]}
+        )
+
+        mock_utc_offset.return_value = "-05:00"
+
+        under_test = process_end_timestamp_for_gtfs_metadata(mock_gtfs_representation)
+        self.assertIsInstance(under_test, GtfsRepresentation)
+        mock_metadata.end_timestamp.assert_not_called()
+
+    @mock.patch("usecase.process_timestamp_for_gtfs_metadata.get_gtfs_dates_by_type")
+    @mock.patch(
+        "usecase.process_timestamp_for_gtfs_metadata.get_gtfs_timezone_utc_offset"
+    )
+    @mock.patch(
+        "usecase.process_timestamp_for_gtfs_metadata.get_gtfs_stop_times_for_date"
+    )
+    def test_process_end_timestamp_execution_with_empty_timezone_utc_offset(
+        self, mock_stop_times_for_date, mock_utc_offset, mock_dates_by_type
+    ):
+        mock_dataset = MagicMock()
+        mock_dataset.__class__ = Feed
+
+        mock_metadata = MagicMock()
+        mock_metadata.__class__ = GtfsMetadata
+
+        mock_gtfs_representation = MagicMock()
+        mock_gtfs_representation.__class__ = GtfsRepresentation
+        type(mock_gtfs_representation).dataset = mock_dataset
+        type(mock_gtfs_representation).metadata = mock_metadata
+
+        mock_stop_times_for_date.return_value = pd.DataFrame(
+            {"trip_id": ["test_trip_id"], "departure_time": ["05:00:00"]}
+        )
+
+        mock_dates_by_type.return_value = pd.DataFrame(
+            {"service_id": ["test_service_id"], "date": ["20201010"]}
+        )
+
+        mock_utc_offset.return_value = ""
+
+        under_test = process_end_timestamp_for_gtfs_metadata(mock_gtfs_representation)
+        self.assertIsInstance(under_test, GtfsRepresentation)
+        mock_metadata.end_timestamp.assert_not_called()

--- a/usecase/test/test_process_start_timestamp_for_gtfs_metadata.py
+++ b/usecase/test/test_process_start_timestamp_for_gtfs_metadata.py
@@ -60,3 +60,106 @@ class TestProcessStartTimestampForGtfsMetadata(TestCase):
         under_test = process_start_timestamp_for_gtfs_metadata(mock_gtfs_representation)
         self.assertIsInstance(under_test, GtfsRepresentation)
         self.assertEqual(mock_metadata.start_timestamp, "2020-10-10T05:00:00-05:00")
+
+    @mock.patch("usecase.process_timestamp_for_gtfs_metadata.get_gtfs_dates_by_type")
+    @mock.patch(
+        "usecase.process_timestamp_for_gtfs_metadata.get_gtfs_timezone_utc_offset"
+    )
+    @mock.patch(
+        "usecase.process_timestamp_for_gtfs_metadata.get_gtfs_stop_times_for_date"
+    )
+    def test_process_start_timestamp_execution_with_empty_dates_by_type(
+        self, mock_stop_times_for_date, mock_utc_offset, mock_dates_by_type
+    ):
+        mock_dataset = MagicMock()
+        mock_dataset.__class__ = Feed
+
+        mock_metadata = MagicMock()
+        mock_metadata.__class__ = GtfsMetadata
+
+        mock_gtfs_representation = MagicMock()
+        mock_gtfs_representation.__class__ = GtfsRepresentation
+        type(mock_gtfs_representation).dataset = mock_dataset
+        type(mock_gtfs_representation).metadata = mock_metadata
+
+        mock_stop_times_for_date.return_value = pd.DataFrame(
+            {"trip_id": ["test_trip_id"], "arrival_time": ["05:00:00"]}
+        )
+
+        mock_dates_by_type.return_value = pd.DataFrame({"service_id": [], "date": []})
+
+        mock_utc_offset.return_value = "-05:00"
+
+        under_test = process_start_timestamp_for_gtfs_metadata(mock_gtfs_representation)
+        self.assertIsInstance(under_test, GtfsRepresentation)
+        mock_metadata.start_timestamp.assert_not_called()
+
+    @mock.patch("usecase.process_timestamp_for_gtfs_metadata.get_gtfs_dates_by_type")
+    @mock.patch(
+        "usecase.process_timestamp_for_gtfs_metadata.get_gtfs_timezone_utc_offset"
+    )
+    @mock.patch(
+        "usecase.process_timestamp_for_gtfs_metadata.get_gtfs_stop_times_for_date"
+    )
+    def test_process_start_timestamp_with_empty_stop_times_for_date(
+        self, mock_stop_times_for_date, mock_utc_offset, mock_dates_by_type
+    ):
+        mock_dataset = MagicMock()
+        mock_dataset.__class__ = Feed
+
+        mock_metadata = MagicMock()
+        mock_metadata.__class__ = GtfsMetadata
+
+        mock_gtfs_representation = MagicMock()
+        mock_gtfs_representation.__class__ = GtfsRepresentation
+        type(mock_gtfs_representation).dataset = mock_dataset
+        type(mock_gtfs_representation).metadata = mock_metadata
+
+        mock_stop_times_for_date.return_value = pd.DataFrame(
+            {"trip_id": [], "arrival_time": []}
+        )
+
+        mock_dates_by_type.return_value = pd.DataFrame(
+            {"service_id": ["test_service_id"], "date": ["20201010"]}
+        )
+
+        mock_utc_offset.return_value = "-05:00"
+
+        under_test = process_start_timestamp_for_gtfs_metadata(mock_gtfs_representation)
+        self.assertIsInstance(under_test, GtfsRepresentation)
+        mock_metadata.start_timestamp.assert_not_called()
+
+    @mock.patch("usecase.process_timestamp_for_gtfs_metadata.get_gtfs_dates_by_type")
+    @mock.patch(
+        "usecase.process_timestamp_for_gtfs_metadata.get_gtfs_timezone_utc_offset"
+    )
+    @mock.patch(
+        "usecase.process_timestamp_for_gtfs_metadata.get_gtfs_stop_times_for_date"
+    )
+    def test_process_start_timestamp_execution_should_set_start_timestamp_metadata(
+        self, mock_stop_times_for_date, mock_utc_offset, mock_dates_by_type
+    ):
+        mock_dataset = MagicMock()
+        mock_dataset.__class__ = Feed
+
+        mock_metadata = MagicMock()
+        mock_metadata.__class__ = GtfsMetadata
+
+        mock_gtfs_representation = MagicMock()
+        mock_gtfs_representation.__class__ = GtfsRepresentation
+        type(mock_gtfs_representation).dataset = mock_dataset
+        type(mock_gtfs_representation).metadata = mock_metadata
+
+        mock_stop_times_for_date.return_value = pd.DataFrame(
+            {"trip_id": ["test_trip_id"], "arrival_time": ["05:00:00"]}
+        )
+
+        mock_dates_by_type.return_value = pd.DataFrame(
+            {"service_id": ["test_service_id"], "date": ["20201010"]}
+        )
+
+        mock_utc_offset.return_value = ""
+
+        under_test = process_start_timestamp_for_gtfs_metadata(mock_gtfs_representation)
+        self.assertIsInstance(under_test, GtfsRepresentation)
+        mock_metadata.start_timestamp.assert_not_called()

--- a/utilities/temporal_utils.py
+++ b/utilities/temporal_utils.py
@@ -106,6 +106,12 @@ def get_gtfs_dates_from_calendar(
                 ]
             day_offset_to_monday = timedelta_operator(day_offset_to_monday, 1) % 7
 
+    # Make sure service_id and date are present for each row of the dataframe before returning it
+    dates_per_service_id_dataframe = dates_per_service_id_dataframe.loc[
+        dates_per_service_id_dataframe[SERVICE_ID].notna()
+        & dates_per_service_id_dataframe[DATE].notna()
+    ]
+
     return dates_per_service_id_dataframe
 
 
@@ -160,21 +166,28 @@ def get_gtfs_timezone_utc_offset(dataset):
     return timezone_offset
 
 
-def get_gtfs_stop_times_for_date(dataset, dataset_dates, date_to_look_up):
+def get_gtfs_stop_times_for_date(
+    dataset, dataset_dates, date_to_look_up, arrival_or_departure_time_key
+):
     # Extract the list of every service ID with date equal to the date to look up
     service_dates = dataset_dates.loc[
         dataset_dates[DATE] == date_to_look_up.strftime(DATE_FORMAT)
     ]
+    service_dates = service_dates.loc[service_dates[SERVICE_ID].notna()]
     service_ids_for_date = service_dates[SERVICE_ID].tolist()
 
     # Extract the list of every trip ID with service ID in the list of service IDs previously extracted
     trips_for_date = dataset.trips.loc[
         dataset.trips[SERVICE_ID].isin(service_ids_for_date)
     ]
+    trips_for_date = trips_for_date.loc[trips_for_date[TRIP_ID].notna()]
     trip_ids_for_date = trips_for_date[TRIP_ID].tolist()
 
     # Extract the stop times with trip ID in the list of trip IDs previously extracted
     stop_times_for_date = dataset.stop_times.loc[
         dataset.stop_times[TRIP_ID].isin(trip_ids_for_date)
+    ]
+    stop_times_for_date = stop_times_for_date.loc[
+        stop_times_for_date[arrival_or_departure_time_key].notna()
     ]
     return stop_times_for_date

--- a/utilities/test/test_temporal_utils.py
+++ b/utilities/test/test_temporal_utils.py
@@ -498,6 +498,10 @@ class TestTemporalUtils(TestCase):
     def test_gtfs_stop_times_for_date_with_valid_parameters_should_return_stop_times_dataframe(
         self, mock_dataset
     ):
+        test_stop_times_trip_ids = ["test_trip_id"]
+        test_stop_times_departure_time = ["05:00:00"]
+        test_stop_time_key = "departure_time"
+
         mock_trips = PropertyMock(
             return_value=pd.DataFrame(
                 {"service_id": ["test_service_id"], "trip_id": ["test_trip_id"]}
@@ -546,11 +550,8 @@ class TestTemporalUtils(TestCase):
         mock_date_to_look_up.__class__ = datetime
         mock_date_to_look_up.strftime.return_value = "20201010"
 
-        test_stop_times_trip_ids = ["test_trip_id"]
-        test_stop_times_departure_time = ["05:00:00"]
-
         under_test = get_gtfs_stop_times_for_date(
-            mock_dataset, mock_dataset_dates, mock_date_to_look_up
+            mock_dataset, mock_dataset_dates, mock_date_to_look_up, test_stop_time_key
         )
         self.assertIsInstance(under_test, pd.DataFrame)
         self.assertTrue("trip_id" in under_test.columns)


### PR DESCRIPTION
**Summary:**

This PR fixes the bug related to #193

This PR contains changes to

- `dataset_infos.py` was modified to add a `__str__()` method for testing purposes
- `temporal_utils.py` was modified to remove rows containing NaN values from dataframes before return
- `process_timestamp_for_gtfs_metadata.py` was modified to verify if the values crashing the use case are not null (pd.NaN)
- New tests were added to `test_process_start_timestamp_for_gtfs_metadata.py` and `test_process_end_timestamp_for_gtfs_metadata.py`


**Expected behavior:** 

The timestamp extraction for the following GTFS dataset must succeed now that the NaN values managed:
https://data.trilliumtransit.com/gtfs/cityoffountaintransit-co-us/cityoffountaintransit-co-us.zip

Please make sure these boxes are checked before submitting your pull request - thanks!

- [x] Run the unit tests with `pytest` to make sure you didn't break anything
- [x] Format the title like "<short description of fix and changes>" (for example - "Check for null value before using field")
- [x] Linked all relevant issues
- [x] Include screenshot(s) showing how this pull request works and fixes the issue(s)